### PR TITLE
Don't make slider ticks on NaN slider velocities

### DIFF
--- a/app/beatmap/objects/slider.go
+++ b/app/beatmap/objects/slider.go
@@ -249,7 +249,7 @@ func (slider *Slider) SetTiming(timings *Timings) {
 
 	for i := int64(0); i < slider.repeat; i++ {
 		distanceToEnd := float64(slider.multiCurve.GetLength())
-		skipTick := false
+		skipTick := math.IsNaN(slider.TPoint.beatLength) // NaN SV acts like 1.0x SV, but doesn't spawn slider ticks
 
 		reverse := (i % 2) == 1
 


### PR DESCRIPTION
makes maps like [Acid Rain](https://osu.ppy.sh/beatmapsets/948643#osu/1981090) and other sliderator "delegate sv to bpm" maps match osu stable behavior and not destroy your ears with slider tick noises