### PR TITLE
Fix ffmpeg being launched incorrectly when combining

### DIFF
--- a/app/ffmpeg/ffmpeg.go
+++ b/app/ffmpeg/ffmpeg.go
@@ -121,7 +121,7 @@ func combine() {
 
 	log.Println("Starting composing audio and video into one file...")
 	log.Println("Running ffmpeg with options:", options)
-	cmd2 := exec.Command("ffmpeg", options...)
+	cmd2 := exec.Command(ffmpegExec, options...)
 
 	if settings.Recording.ShowFFmpegLogs {
 		cmd2.Stdout = os.Stdout


### PR DESCRIPTION
Proposed fix for #243 

I changed the combine to run ffmpeg using `ffmpegExec` rather than `"ffmpeg"`