### PR TITLE
AMD encoding support

### DIFF
--- a/app/settings/recording.go
+++ b/app/settings/recording.go
@@ -61,14 +61,18 @@ func initRecording() *recording {
 			Preset:            "slow",
 			AdditionalOptions: "",
 		},
+		H264AMDSettings: &vce264Settings{
+			RateControl: "qp",
+			Preset:      "balanced",
+			Bitrate:     "10M",
+		},
+		HEVCAMDSettings: &vce265Settings{
+			RateControl: "qp",
+			Preset:      "balanced",
+			Bitrate:     "10M",
+		},
 		CustomSettings: &custom{
 			CustomOptions: "",
-		},
-		H264AMDSettings: &custom{
-			CustomOptions: "-quality 0 -rc 0",
-		},
-		HEVCAMDSettings: &custom{
-			CustomOptions: "-quality 0 -rc 0",
 		},
 		PixelFormat: "yuv420p",
 		Filters:     "",
@@ -121,8 +125,8 @@ type recording struct {
 	HEVCNvencSettings   *hevcNvencSettings `json:"hevc_nvenc" label:"NVIDIA NVENC H.265 (HEVC) Settings" showif:"Encoder=hevc_nvenc"`
 	H264QSVSettings     *h264QSVSettings   `json:"h264_qsv" label:"Intel QuickSync H.264 (AVC) Settings" showif:"Encoder=h264_qsv"`
 	HEVCQSVSettings     *hevcQSVSettings   `json:"hevc_qsv" label:"Intel QuickSync H.265 (HEVC) Settings" showif:"Encoder=hevc_qsv"`
-	H264AMDSettings     *custom            `json:"h264_amf" label:"AMD VCE (H.264) Settings" showif:"Encoder=h264_amf"`
-	HEVCAMDSettings     *custom            `json:"hevc_amf" label:"AMD VCE (HEVC) Settings" showif:"Encoder=hevc_amf"`
+	H264AMDSettings     *vce264Settings    `json:"h264_amf" label:"AMD VCE (H.264) Settings" showif:"Encoder=h264_amf"`
+	HEVCAMDSettings     *vce265Settings    `json:"hevc_amf" label:"AMD VCE (HEVC) Settings" showif:"Encoder=hevc_amf"`
 	CustomSettings      *custom            `json:"custom" label:"Custom Encoder Settings" showif:"Encoder=!"`
 	PixelFormat         string             `combo:"yuv420p|I420,yuv444p|I444,nv12|NV12,nv21|NV21" showif:"Encoder=!h264_qsv,!hevc_qsv"`
 	Filters             string             `label:"FFmpeg Video Filters"`

--- a/app/settings/recording.go
+++ b/app/settings/recording.go
@@ -1,9 +1,10 @@
 package settings
 
 import (
-	"github.com/wieku/danser-go/framework/env"
 	"path/filepath"
 	"strings"
+
+	"github.com/wieku/danser-go/framework/env"
 )
 
 var Recording = initRecording()
@@ -63,6 +64,12 @@ func initRecording() *recording {
 		CustomSettings: &custom{
 			CustomOptions: "",
 		},
+		H264AMDSettings: &custom{
+			CustomOptions: "-quality 0 -rc 0",
+		},
+		HEVCAMDSettings: &custom{
+			CustomOptions: "-quality 0 -rc 0",
+		},
 		PixelFormat: "yuv420p",
 		Filters:     "",
 		AudioCodec:  "aac",
@@ -107,13 +114,15 @@ type recording struct {
 	FrameHeight         int                `min:"1" max:"17280"`
 	FPS                 int                `label:"FPS (PLEASE READ TOOLTIP)" string:"true" min:"1" max:"10727" tooltip:"IMPORTANT: If you plan to have a \"high fps\" video, use Motion Blur below instead of setting FPS to absurd numbers. Setting the value too high will result in a broken video!"`
 	EncodingFPSCap      int                `string:"true" min:"0" max:"10727" label:"Max Encoding FPS (Speed)" tooltip:"Limits the speed at which danser renders the video. If FPS is set to 60 and this option to 30, then it means 2 minute map will take at least 4 minutes to render"`
-	Encoder             string             `combo:"libx264|Software x264 (AVC),libx265|Software x265 (HEVC),h264_nvenc|NVIDIA NVENC H.264 (AVC),hevc_nvenc|NVIDIA NVENC H.265 (HEVC),h264_qsv|Intel QuickSync H.264 (AVC),hevc_qsv|Intel QuickSync H.265 (HEVC)" tooltip:"Hardware encoding with AMD GPUs is not supported because software encoding provides better performance and results"`
+	Encoder             string             `combo:"libx264|Software x264 (AVC),libx265|Software x265 (HEVC),h264_nvenc|NVIDIA NVENC H.264 (AVC),hevc_nvenc|NVIDIA NVENC H.265 (HEVC),h264_qsv|Intel QuickSync H.264 (AVC),hevc_qsv|Intel QuickSync H.265 (HEVC),h264_amf|AMD VCE (H.264),hevc_amf|AMD VCE (HEVC)" tooltip:"Hardware encoding with AMD GPUs is experimental in this build"`
 	X264Settings        *x264Settings      `json:"libx264" label:"Software x264 (AVC) Settings" showif:"Encoder=libx264"`
 	X265Settings        *x265Settings      `json:"libx265" label:"Software x265 (HEVC) Settings" showif:"Encoder=libx265"`
 	H264NvencSettings   *h264NvencSettings `json:"h264_nvenc" label:"NVIDIA NVENC H.264 (AVC) Settings" showif:"Encoder=h264_nvenc"`
 	HEVCNvencSettings   *hevcNvencSettings `json:"hevc_nvenc" label:"NVIDIA NVENC H.265 (HEVC) Settings" showif:"Encoder=hevc_nvenc"`
 	H264QSVSettings     *h264QSVSettings   `json:"h264_qsv" label:"Intel QuickSync H.264 (AVC) Settings" showif:"Encoder=h264_qsv"`
 	HEVCQSVSettings     *hevcQSVSettings   `json:"hevc_qsv" label:"Intel QuickSync H.265 (HEVC) Settings" showif:"Encoder=hevc_qsv"`
+	H264AMDSettings     *custom            `json:"h264_amf" label:"AMD VCE (H.264) Settings" showif:"Encoder=h264_amf"`
+	HEVCAMDSettings     *custom            `json:"hevc_amf" label:"AMD VCE (HEVC) Settings" showif:"Encoder=hevc_amf"`
 	CustomSettings      *custom            `json:"custom" label:"Custom Encoder Settings" showif:"Encoder=!"`
 	PixelFormat         string             `combo:"yuv420p|I420,yuv444p|I444,nv12|NV12,nv21|NV21" showif:"Encoder=!h264_qsv,!hevc_qsv"`
 	Filters             string             `label:"FFmpeg Video Filters"`
@@ -147,6 +156,10 @@ func (g *recording) GetEncoderOptions() EncoderOptions {
 		return g.H264QSVSettings
 	case "hevc_qsv":
 		return g.HEVCQSVSettings
+	case "h264_amf":
+		return g.H264AMDSettings
+	case "hevc_amf":
+		return g.HEVCAMDSettings
 	default:
 		return g.CustomSettings
 	}

--- a/app/settings/recordingvce.go
+++ b/app/settings/recordingvce.go
@@ -1,0 +1,95 @@
+package settings
+
+import (
+	"fmt"
+	"strings"
+)
+
+type vce264Settings struct {
+	RateControl       string `combo:"qp|Quality Preset,cbr|CBR"`
+	Bitrate           string `showif:"RateControl=cbr"`
+	Preset            string `combo:"speed|Speed,balanced|Balanced,quality|Quality" showif:"RateControl=qp"`
+	AdditionalOptions string
+}
+
+func (s *vce264Settings) GenerateFFmpegArgs() (ret []string, err error) {
+	ret, err = vce264Common(s.RateControl, s.Bitrate, s.Preset)
+	if err != nil {
+		return nil, err
+	}
+
+	ret2, err := vceCommon2(s.Preset, s.AdditionalOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(ret, ret2...), nil
+}
+
+type vce265Settings struct {
+	RateControl       string `combo:"qp|Quality Preset,cbr|CBR"`
+	Bitrate           string `showif:"RateControl=cbr"`
+	Preset            string `combo:"speed|Speed,balanced|Balanced,quality|Quality" showif:"RateControl=qp"`
+	AdditionalOptions string
+}
+
+func (s *vce265Settings) GenerateFFmpegArgs() (ret []string, err error) {
+	ret, err = vce265Common(s.RateControl, s.Bitrate, s.Preset)
+	if err != nil {
+		return nil, err
+	}
+
+	ret2, err := vceCommon2(s.Preset, s.AdditionalOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(ret, ret2...), nil
+}
+
+func vce264Common(rateControl string, bitrate string, qp string) (ret []string, err error) {
+	switch strings.ToLower(rateControl) {
+	case "qp":
+		if qp == "quality" {
+			ret = append(ret, "-quality", "2", "-rc", "0")
+		} else if qp == "balanced" {
+			ret = append(ret, "-quality", "0", "-rc", "0")
+		} else if qp == "speed" {
+			ret = append(ret, "-quality", "1", "-rc", "0")
+		} else {
+			return nil, fmt.Errorf("Invalid preset")
+		}
+	case "cbr":
+		ret = append(ret, "-rc", "1", "-b:v", bitrate)
+	default:
+		return nil, fmt.Errorf("invalid rate control value: %s", rateControl)
+	}
+	return
+}
+
+func vce265Common(rateControl string, bitrate string, qp string) (ret []string, err error) {
+	switch strings.ToLower(rateControl) {
+	case "qp":
+		if qp == "quality" {
+			ret = append(ret, "-quality", "0", "-rc", "0")
+		} else if qp == "balanced" {
+			ret = append(ret, "-quality", "5", "-rc", "0")
+		} else if qp == "speed" {
+			ret = append(ret, "-quality", "10", "-rc", "0")
+		} else {
+			return nil, fmt.Errorf("Invalid preset")
+		}
+	case "cbr":
+		ret = append(ret, "-rc", "1", "-b:v", bitrate)
+	default:
+		return nil, fmt.Errorf("invalid rate control value: %s", rateControl)
+	}
+	return
+}
+
+func vceCommon2(preset string, additional string) (ret []string, err error) {
+
+	ret = parseCustomOptions(ret, additional)
+
+	return
+}


### PR DESCRIPTION
Not sure if this will work perfectly but I will continue to contribute to this request. I know support for AMD hardware encoding was dropped, but at least knowing the risk in edge cases like low-end CPU this may help. And there is also an opened issue about AMD pro drivers on Linux, which may help encoding work better there (not sure though, for now I can only test Windows support, but eventually I'll get working on a Linux support too). For the time being, while support is experimental I will build a forked version with changes I made there. If anyone's interested, testing will be greatly helpful.