### PR TITLE
fix: add warm-up render to screenshot mode to ensure slider tick points are visible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,3 +172,4 @@ jobs:
           gh release create "$TAGNAME" --draft -t "$NAME" --target "master" $(for a in artifacts/*.{zip,tar.xz}; do echo $a; done)
         env:
           GITHUB_TOKEN: ${{ github.token }}
+

--- a/app/app.go
+++ b/app/app.go
@@ -708,22 +708,32 @@ func mainLoopSS() {
 
 	for !p.Update(1) {
 		if p.GetTime() >= screenshotTime*1000 {
-			log.Println("Scheduling screenshot")
-			goroutines.CallMain(func() {
-				fbo.Bind()
-
-				viewport.Push(int(settings.Graphics.GetWidth()), int(settings.Graphics.GetHeight()))
-				pushFrame()
-				viewport.Pop()
-
-				utils.MakeScreenshot(int(settings.Graphics.GetWidth()), int(settings.Graphics.GetHeight()), output, false)
-
-				fbo.Unbind()
-			})
-
 			break
 		}
 	}
+
+	goroutines.CallMain(func() {
+		fbo.Bind()
+
+		viewport.Push(int(settings.Graphics.GetWidth()), int(settings.Graphics.GetHeight()))
+		pushFrame()
+		viewport.Pop()
+
+		fbo.Unbind()
+	})
+
+	log.Println("Scheduling screenshot")
+	goroutines.CallMain(func() {
+		fbo.Bind()
+
+		viewport.Push(int(settings.Graphics.GetWidth()), int(settings.Graphics.GetHeight()))
+		pushFrame()
+		viewport.Pop()
+
+		utils.MakeScreenshot(int(settings.Graphics.GetWidth()), int(settings.Graphics.GetHeight()), output, false)
+
+		fbo.Unbind()
+	})
 }
 
 func mainLoopNormal() {


### PR DESCRIPTION
Fixes slider tick points missing when using `-ss`, even though they showed up in videos or normal playback.

## Summary
- add a quick warm-up render before taking a screenshot so textures finish loading
- second render captures the actual screenshot with slider tick points visible

## Testing
Verified with: `.\danser-go.exe -replay "replay.osr" -skip -ss 0.33`

Highly recommend reviewing the code and feel free to close if you have a better solution.

Closes https://github.com/Wieku/danser-go/issues/431