### PR TITLE
Add VAAPI hardware video encoding support

### DIFF
--- a/app/ffmpeg/video.go
+++ b/app/ffmpeg/video.go
@@ -92,7 +92,7 @@ func startVideo(fps, _w, _h int) {
 	encoder := strings.ToLower(settings.Recording.Encoder)
 	outputFormat := strings.ToLower(settings.Recording.PixelFormat)
 
-	if strings.HasSuffix(encoder, "_qsv") { // qsv works best with nv12 format
+	if strings.HasSuffix(encoder, "_qsv") || strings.HasSuffix(encoder, "_vaapi") { // qsv and vaapi work best with nv12 format
 		outputFormat = "nv12"
 	} else if encoder == "libsvtav1" {
 		outputFormat = "yuv420p"

--- a/app/settings/recording.go
+++ b/app/settings/recording.go
@@ -103,6 +103,32 @@ func initRecording() *recording {
 			Preset:            "high_quality",
 			AdditionalOptions: "",
 		},
+		H264VaapiSettings: &h264VaapiSettings{
+			Device:            "/dev/dri/renderD128",
+			RateControl:       "cqp",
+			Bitrate:           "10M",
+			QP:                20,
+			Profile:           "high",
+			AdditionalOptions: "",
+		},
+		HEVCVaapiSettings: &hevcVaapiSettings{
+			Device:            "/dev/dri/renderD128",
+			RateControl:       "icq",
+			Bitrate:           "10M",
+			QP:                22,
+			Quality:           22,
+			Profile:           "main",
+			AdditionalOptions: "",
+		},
+		AV1VaapiSettings: &av1VaapiSettings{
+			Device:            "/dev/dri/renderD128",
+			RateControl:       "icq",
+			Bitrate:           "10M",
+			QP:                24,
+			Quality:           24,
+			CompressionLevel:  4,
+			AdditionalOptions: "",
+		},
 		CustomSettings: &custom{
 			CustomOptions: "",
 		},
@@ -150,7 +176,7 @@ type recording struct {
 	FrameHeight         int                `min:"1" max:"17280"`
 	FPS                 int                `label:"FPS (PLEASE READ TOOLTIP)" string:"true" min:"1" max:"10727" tooltip:"IMPORTANT: If you plan to have a \"high fps\" video, use Motion Blur below instead of setting FPS to absurd numbers. Setting the value too high will result in a broken video!"`
 	EncodingFPSCap      int                `string:"true" min:"0" max:"10727" label:"Max Encoding FPS (Speed)" tooltip:"Limits the speed at which danser renders the video. If FPS is set to 60 and this option to 30, then it means 2 minute map will take at least 4 minutes to render"`
-	Encoder             string             `combo:"libx264|Software x264 (AVC),libx265|Software x265 (HEVC),libsvtav1|Software AV1,h264_nvenc|NVIDIA NVENC H.264 (AVC),hevc_nvenc|NVIDIA NVENC H.265 (HEVC),av1_nvenc|NVIDIA NVENC AV1,h264_qsv|Intel QuickSync H.264 (AVC),hevc_qsv|Intel QuickSync H.265 (HEVC),h264_amf|AMD AMF H.264 (AVC),hevc_amf|AMD AMF H.265 (HEVC),av1_amf|AMD AMF AV1" comboSrc:"EncoderOptions"`
+	Encoder             string             `combo:"libx264|Software x264 (AVC),libx265|Software x265 (HEVC),libsvtav1|Software AV1,h264_nvenc|NVIDIA NVENC H.264 (AVC),hevc_nvenc|NVIDIA NVENC H.265 (HEVC),av1_nvenc|NVIDIA NVENC AV1,h264_qsv|Intel QuickSync H.264 (AVC),hevc_qsv|Intel QuickSync H.265 (HEVC),h264_amf|AMD AMF H.264 (AVC),hevc_amf|AMD AMF H.265 (HEVC),av1_amf|AMD AMF AV1,h264_vaapi|VAAPI H.264 (AVC),hevc_vaapi|VAAPI HEVC,av1_vaapi|VAAPI AV1" comboSrc:"EncoderOptions"`
 	X264Settings        *x264Settings      `json:"libx264" label:"Software x264 (AVC) Settings" showif:"Encoder=libx264"`
 	X265Settings        *x265Settings      `json:"libx265" label:"Software x265 (HEVC) Settings" showif:"Encoder=libx265"`
 	AV1Settings         *av1Settings       `json:"libsvtav1" label:"Software AV1 Settings" showif:"Encoder=libsvtav1"`
@@ -162,8 +188,11 @@ type recording struct {
 	H264AmfSettings     *h264AmfSettings   `json:"h264_amf" label:"AMD AMF H.264 (AVC) Settings" showif:"Encoder=h264_amf"`
 	HEVCAmfSettings     *hevcAmfSettings   `json:"hevc_amf" label:"AMD AMF H.265 (HEVC) Settings" showif:"Encoder=hevc_amf"`
 	AV1AmfSettings      *av1AmfSettings    `json:"av1_amf" label:"AMD AMF AV1 Settings" showif:"Encoder=av1_amf"`
+	H264VaapiSettings   *h264VaapiSettings `json:"h264_vaapi" label:"VAAPI H.264 (AVC) Settings" showif:"Encoder=h264_vaapi"`
+	HEVCVaapiSettings   *hevcVaapiSettings `json:"hevc_vaapi" label:"VAAPI HEVC Settings" showif:"Encoder=hevc_vaapi"`
+	AV1VaapiSettings    *av1VaapiSettings  `json:"av1_vaapi" label:"VAAPI AV1 Settings" showif:"Encoder=av1_vaapi"`
 	CustomSettings      *custom            `json:"custom" label:"Custom Encoder Settings" showif:"Encoder=!"`
-	PixelFormat         string             `combo:"yuv420p|I420,yuv444p|I444,nv12|NV12" showif:"Encoder=!h264_qsv,!hevc_qsv,!libsvtav1"`
+	PixelFormat         string             `combo:"yuv420p|I420,yuv444p|I444,nv12|NV12" showif:"Encoder=!h264_qsv,!hevc_qsv,!libsvtav1,!h264_vaapi,!hevc_vaapi,!av1_vaapi"`
 	Filters             string             `label:"FFmpeg Video Filters"`
 	AudioCodec          string             `combo:"aac|AAC,libmp3lame|MP3,libopus|OPUS,flac|FLAC"`
 	AACSettings         *aacSettings       `json:"aac" label:"AAC Settings" showif:"AudioCodec=aac"`
@@ -205,6 +234,12 @@ func (g *recording) GetEncoderOptions() EncoderOptions {
 		return g.HEVCAmfSettings
 	case "av1_amf":
 		return g.AV1AmfSettings
+	case "h264_vaapi":
+		return g.H264VaapiSettings
+	case "hevc_vaapi":
+		return g.HEVCVaapiSettings
+	case "av1_vaapi":
+		return g.AV1VaapiSettings
 	default:
 		return g.CustomSettings
 	}
@@ -303,7 +338,15 @@ func (d *defaultsFactory) EncoderOptions() []string {
 		toRemove := util.Balance(8, encoderCache, func(encoder string) (string, bool) {
 			eName := strings.Split(encoder, "|")[0]
 
-			cmd, err := platform.PrepareFFMpeg("ffmpeg", "-f", "lavfi", "-i", "color=black:s=240x144", "-vframes", "1", "-an", "-c:v", eName, "-f", "null", "-")
+			args := []string{"-f", "lavfi", "-i", "color=black:s=240x144", "-vframes", "1", "-an", "-c:v", eName}
+
+			if strings.HasSuffix(eName, "_vaapi") {
+				args = append(args, "-vaapi_device", "/dev/dri/renderD128", "-vf", "format=nv12,hwupload")
+			}
+
+			args = append(args, "-f", "null", "-")
+
+			cmd, err := platform.PrepareFFMpeg("ffmpeg", args...)
 
 			if err != nil {
 				return "", false

--- a/app/settings/recordingvaapi.go
+++ b/app/settings/recordingvaapi.go
@@ -1,0 +1,149 @@
+package settings
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var vaapiH264Profiles = []string{
+	"baseline",
+	"main",
+	"high",
+}
+
+var vaapiH265Profiles = []string{
+	"main",
+	"main10",
+}
+
+type h264VaapiSettings struct {
+	Device            string `label:"VAAPI Device Path" tooltip:"Path to the VAAPI render device, defaults to /dev/dri/renderD128"`
+	RateControl       string `combo:"cqp|Constant Quantization (CQP),cbr|Constant Bitrate (CBR),vbr|Variable Bitrate (VBR)"`
+	Bitrate           string `showif:"RateControl=cbr,vbr"`
+	QP                int    `string:"true" min:"0" max:"51" showif:"RateControl=cqp"`
+	Profile           string `combo:"baseline|Baseline,main|Main,high|High"`
+	AdditionalOptions string
+}
+
+func (s *h264VaapiSettings) GenerateFFmpegArgs() (ret []string, err error) {
+	ret, err = vaapiCommon(s.Device, s.RateControl, s.Bitrate, s.QP, "h264_vaapi")
+	if err != nil {
+		return nil, err
+	}
+
+	if !slices.Contains(vaapiH264Profiles, s.Profile) {
+		return nil, fmt.Errorf("invalid profile: %s", s.Profile)
+	}
+
+	ret = append(ret, "-profile:v", s.Profile)
+
+	ret = parseCustomOptions(ret, s.AdditionalOptions)
+
+	return
+}
+
+type hevcVaapiSettings struct {
+	Device            string `label:"VAAPI Device Path" tooltip:"Path to the VAAPI render device, defaults to /dev/dri/renderD128"`
+	RateControl       string `combo:"cqp|Constant Quantization (CQP),cbr|Constant Bitrate (CBR),vbr|Variable Bitrate (VBR),icq|Intelligent Constant Quality (ICQ)"`
+	Bitrate           string `showif:"RateControl=cbr,vbr"`
+	QP                int    `string:"true" min:"0" max:"51" showif:"RateControl=cqp"`
+	Quality           int    `string:"true" min:"1" max:"51" showif:"RateControl=icq"`
+	Profile           string `combo:"main|Main,main10|Main10"`
+	AdditionalOptions string
+}
+
+func (s *hevcVaapiSettings) GenerateFFmpegArgs() (ret []string, err error) {
+	ret, err = vaapiCommon(s.Device, s.RateControl, s.Bitrate, s.QP, "hevc_vaapi")
+	if err != nil {
+		return nil, err
+	}
+
+	// HEVC ICQ uses -global_quality instead of -qp
+	if strings.ToLower(s.RateControl) == "icq" {
+		if s.Quality < 1 || s.Quality > 51 {
+			return nil, fmt.Errorf("Quality parameter out of range [1-51]")
+		}
+
+		ret = append(ret, "-global_quality", strconv.Itoa(s.Quality))
+	}
+
+	if !slices.Contains(vaapiH265Profiles, s.Profile) {
+		return nil, fmt.Errorf("invalid profile: %s", s.Profile)
+	}
+
+	ret = append(ret, "-profile:v", s.Profile)
+
+	ret = parseCustomOptions(ret, s.AdditionalOptions)
+
+	return
+}
+
+type av1VaapiSettings struct {
+	Device            string `label:"VAAPI Device Path" tooltip:"Path to the VAAPI render device, defaults to /dev/dri/renderD128"`
+	RateControl       string `combo:"cqp|Constant Quantization (CQP),cbr|Constant Bitrate (CBR),vbr|Variable Bitrate (VBR),icq|Intelligent Constant Quality (ICQ),qvbr|Quality Variable Bitrate (QVBR)"`
+	Bitrate           string `showif:"RateControl=cbr,vbr,qvbr"`
+	QP                int    `string:"true" min:"0" max:"51" showif:"RateControl=cqp"`
+	Quality           int    `string:"true" min:"1" max:"51" showif:"RateControl=icq,qvbr"`
+	CompressionLevel  int    `string:"true" min:"0" max:"7" label:"Compression Level" tooltip:"Trade encoding speed for compression efficiency. 0 is fastest, 7 is most efficient."`
+	AdditionalOptions string
+}
+
+func (s *av1VaapiSettings) GenerateFFmpegArgs() (ret []string, err error) {
+	ret, err = vaapiCommon(s.Device, s.RateControl, s.Bitrate, s.QP, "av1_vaapi")
+	if err != nil {
+		return nil, err
+	}
+
+	// AV1 ICQ/QVBR uses -global_quality instead of -qp
+	if strings.ToLower(s.RateControl) == "icq" || strings.ToLower(s.RateControl) == "qvbr" {
+		if s.Quality < 1 || s.Quality > 51 {
+			return nil, fmt.Errorf("Quality parameter out of range [1-51]")
+		}
+
+		ret = append(ret, "-global_quality", strconv.Itoa(s.Quality))
+	}
+
+	if s.CompressionLevel < 0 || s.CompressionLevel > 7 {
+		return nil, fmt.Errorf("CompressionLevel parameter out of range [0-7]")
+	}
+
+	ret = append(ret, "-compression_level", strconv.Itoa(s.CompressionLevel))
+
+	ret = parseCustomOptions(ret, s.AdditionalOptions)
+
+	return
+}
+
+func vaapiCommon(device, rateControl, bitrate string, qp int, encoderType string) (ret []string, err error) {
+	if device != "" {
+		ret = append(ret, "-vaapi_device", device)
+	}
+
+	// Hardware upload filter; the nv12 format override is applied in video.go
+	ret = append(ret, "-vf", "format=nv12,hwupload")
+
+	switch strings.ToLower(rateControl) {
+	case "cqp":
+		if qp < 0 || qp > 51 {
+			return nil, fmt.Errorf("QP parameter out of range [0-51]")
+		}
+
+		ret = append(ret, "-rc_mode", "CQP", "-qp", strconv.Itoa(qp))
+	case "cbr":
+		ret = append(ret, "-rc_mode", "CBR", "-b:v", bitrate)
+	case "vbr":
+		ret = append(ret, "-rc_mode", "VBR", "-b:v", bitrate)
+	case "icq", "qvbr":
+		// ICQ/QVBR handled in the caller (different per codec)
+		// For h264: ICQ not supported, so this falls through to the error below
+		// For hevc: -global_quality set by caller
+		// For av1: ICQ and QVBR use -global_quality set by caller
+		return
+	default:
+		return nil, fmt.Errorf("invalid rate control value: %s", rateControl)
+	}
+
+	return
+}


### PR DESCRIPTION
## Overview

Related issue: #413 

Adds Linux VAAPI hardware video encoding support with three encoder options: `h264_vaapi`, `hevc_vaapi`, and `av1_vaapi`.

Tested on Fedora Linux 44 + AMD Radeon RX 7900 XT.

## Changed Files

### 1. `app/settings/recordingvaapi.go` (new)

Three encoder settings structs, all implementing the `EncoderOptions` interface:

| Struct | Encoder | Rate Control Modes |
|---|---|---|
| `h264VaapiSettings` | `h264_vaapi` | CQP / CBR / VBR |
| `hevcVaapiSettings` | `hevc_vaapi` | CQP / CBR / VBR / ICQ |
| `av1VaapiSettings` | `av1_vaapi` | CQP / CBR / VBR / ICQ / QVBR |

Shared function `vaapiCommon()` generates common arguments:
- `-vaapi_device <path>` (device path, defaults to `/dev/dri/renderD128`)
- `-vf format=nv12,hwupload` (hardware surface upload)
- Per RC mode: `-rc_mode CQP -qp N` / `-rc_mode CBR -b:v N` / `-rc_mode VBR -b:v N`
- HEVC ICQ and AV1 ICQ/QVBR use `-global_quality` (instead of `-qp`)
- AV1 additionally supports `-compression_level` (0–7)

### 2. `app/settings/recording.go`

- Appended `h264_vaapi|VAAPI H.264 (AVC),hevc_vaapi|VAAPI HEVC,av1_vaapi|VAAPI AV1` to the `Encoder` field
- Added `H264VaapiSettings`, `HEVCVaapiSettings`, `AV1VaapiSettings` with `showif` and `json` tags
- Initialized default parameters for all three encoders in `initRecording()`
- Added three `case` branches in `GetEncoderOptions()`
- Excluded VAAPI encoders in `showif` (VAAPI forces nv12)
- In the `EncoderOptions()` probe loop, VAAPI-suffixed encoders automatically get `-vaapi_device /dev/dri/renderD128 -vf format=nv12,hwupload` appended. Without this, VAAPI encoders fail the probe test and are incorrectly filtered out of the UI.

### 3. `app/ffmpeg/video.go`

- `_vaapi` suffixed encoders are forced to `nv12` pixel format.