### PR TITLE
Update lazer scoring and 2026 Q2 PP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,16 @@ jobs:
           go-version: '1.26.1'
           cache: true
 
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.14.0'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Build danser
         run: |
           version="${{ inputs.version }}"
@@ -123,6 +133,16 @@ jobs:
         with:
           go-version: '1.26.1'
           cache: true
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.14.0'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Build danser
         run: |

--- a/app/beatmap/difficulty/difficulty.go
+++ b/app/beatmap/difficulty/difficulty.go
@@ -391,29 +391,23 @@ func (diff *Difficulty) GetRadius() float32 {
 }
 
 func (diff *Difficulty) GetScoreMultiplier() float64 {
+	if diff.Mods.Active(Lazer) {
+		return diff.getLazerScoreMultiplier()
+	}
+
 	baseMultiplier := (diff.Mods & (^(HalfTime | Daycore | DoubleTime | Nightcore | Flashlight))).GetScoreMultiplier()
 
-	if diff.Mods.Active(Lazer) {
-		value := math.Floor(diff.Speed*10)/10 - 1
-
-		if diff.Speed >= 1 {
-			baseMultiplier *= 1 + value/5
+	if diff.Speed > 1 {
+		if diff.Mods.Active(ScoreV2) {
+			baseMultiplier *= 1 + (0.40 * (diff.Speed - 1))
 		} else {
-			baseMultiplier *= 0.6 + value
+			baseMultiplier *= 1 + (0.24 * (diff.Speed - 1))
 		}
-	} else {
-		if diff.Speed > 1 {
-			if diff.Mods.Active(ScoreV2) {
-				baseMultiplier *= 1 + (0.40 * (diff.Speed - 1))
-			} else {
-				baseMultiplier *= 1 + (0.24 * (diff.Speed - 1))
-			}
-		} else if diff.Speed < 1 {
-			if diff.Speed >= 0.75 {
-				baseMultiplier *= 0.3 + 0.7*(1-(1-diff.Speed)/0.25)
-			} else {
-				baseMultiplier *= max(0, 0.3*(1-(0.75-diff.Speed)/0.75))
-			}
+	} else if diff.Speed < 1 {
+		if diff.Speed >= 0.75 {
+			baseMultiplier *= 0.3 + 0.7*(1-(1-diff.Speed)/0.25)
+		} else {
+			baseMultiplier *= max(0, 0.3*(1-(0.75-diff.Speed)/0.75))
 		}
 	}
 
@@ -430,6 +424,87 @@ func (diff *Difficulty) GetScoreMultiplier() float64 {
 	}
 
 	return baseMultiplier
+}
+
+func (diff *Difficulty) getLazerScoreMultiplier() float64 {
+	multiplier := 1.0
+
+	if diff.Mods.Active(NoFail) {
+		multiplier *= 0.5
+	}
+	if diff.Mods.Active(Easy) {
+		retries := NewEasySettings().Retries
+		if config, ok := GetModConfig[EasySettings](diff); ok {
+			retries = config.Retries
+		}
+		multiplier *= max(0.4, 0.8-max(0, 0.1*float64(retries-NewEasySettings().Retries)))
+	}
+	if diff.Mods.Active(HardRock) {
+		multiplier *= 1.09
+	}
+	if diff.Mods.Active(Hidden) {
+		multiplier *= 1.04
+	}
+	if diff.Mods.Active(Target) {
+		multiplier *= 0.01
+	}
+	if diff.Mods.Active(Classic) {
+		classicNoteLock := NewClassicSettings().ClassicNoteLock
+		if config, ok := GetModConfig[ClassicSettings](diff); ok {
+			classicNoteLock = config.ClassicNoteLock
+		}
+		if classicNoteLock {
+			multiplier *= 0.985
+		} else {
+			multiplier *= 0.96
+		}
+	}
+	if diff.Mods.Active(Random) {
+		multiplier *= 0.7
+	}
+	if diff.Mods.Active(Relax) || diff.Mods.Active(Relax2) {
+		multiplier *= 0.1
+	}
+	if diff.Mods.Active(SpunOut) {
+		multiplier *= 0.95
+	}
+	if diff.Mods.Active(Traceable) {
+		multiplier *= 1.02
+	}
+
+	if diff.Speed >= 1 {
+		value := math.Floor(diff.Speed*10) / 10
+		penalty := 0.0
+		if value != 1 && value != 1.5 {
+			penalty = 0.01
+		}
+		multiplier *= (value-1)*0.46 + 1 - penalty
+	} else {
+		multiplier *= math.Floor(diff.Speed*20)/20*1.4 - 0.5
+	}
+
+	if diff.Mods.Active(Flashlight) {
+		config := NewFlashlightSettings()
+		if custom, ok := GetModConfig[FlashlightSettings](diff); ok {
+			config = custom
+		}
+
+		flashlightMultiplier := mutils.Clamp(1.2-0.2*(config.SizeMultiplier-1), 1.02, 1.2)
+		if !config.ComboBasedSize {
+			flashlightMultiplier = 1 + (flashlightMultiplier-1)/5
+		}
+		multiplier *= flashlightMultiplier
+	}
+
+	if diff.Mods.Active(DifficultyAdjust) {
+		csMultiplier := max(0.1, 1-math.Abs(diff.GetCS()-diff.GetBaseCS())*0.5)
+		hpMultiplier := max(0.1, 1-math.Abs(diff.GetHP()-diff.GetBaseHP())*0.5)
+		odMultiplier := max(0.1, 1-math.Abs(diff.GetOD()-diff.GetBaseOD())*0.5)
+		arMultiplier := max(0.1, 1-math.Abs(diff.GetAR()-diff.GetBaseAR())*0.5)
+		multiplier *= max(0.1, csMultiplier*hpMultiplier*odMultiplier*arMultiplier)
+	}
+
+	return multiplier
 }
 
 func (diff *Difficulty) GetModStringFull() []string {

--- a/app/beatmap/difficulty/score_multiplier_test.go
+++ b/app/beatmap/difficulty/score_multiplier_test.go
@@ -1,0 +1,32 @@
+package difficulty
+
+import (
+	"math"
+	"testing"
+)
+
+func TestLazerScoreMultipliers(t *testing.T) {
+	tests := []struct {
+		name string
+		mods Modifier
+		want float64
+	}{
+		{"HardRock", HardRock, 1.09},
+		{"HiddenHardRock", Hidden | HardRock, 1.04 * 1.09},
+		{"DoubleTime", DoubleTime, 1.23},
+		{"HalfTime", HalfTime, 0.55},
+		{"Flashlight", Flashlight, 1.2},
+		{"Classic", Classic, 0.985},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diff := NewDifficulty(5, 5, 5, 5)
+			diff.SetMods(Lazer | test.mods)
+
+			if got := diff.GetScoreMultiplier(); math.Abs(got-test.want) > 1e-12 {
+				t.Fatalf("got %.12f, want %.12f", got, test.want)
+			}
+		})
+	}
+}

--- a/app/database/manager.go
+++ b/app/database/manager.go
@@ -17,7 +17,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/wieku/danser-go/app/beatmap"
-	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp250306"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp260727"
 	"github.com/wieku/danser-go/app/settings"
 	"github.com/wieku/danser-go/app/utils"
 	"github.com/wieku/danser-go/framework/env"
@@ -48,7 +48,7 @@ var migrations []Migration
 
 var songsDir string
 
-var difficultyCalc = pp250306.NewDifficultyCalculator()
+var difficultyCalc = pp260727.NewDifficultyCalculator()
 
 func Init() error {
 	log.Println("DatabaseManager: Initializing database...")

--- a/app/rulesets/osu/lazer_judgement_test.go
+++ b/app/rulesets/osu/lazer_judgement_test.go
@@ -1,0 +1,40 @@
+package osu
+
+import (
+	"testing"
+
+	"github.com/wieku/danser-go/app/beatmap/difficulty"
+)
+
+func TestLazerHitWindowIntegerBoundaries(t *testing.T) {
+	diff := difficulty.NewDifficulty(5, 5, 10, 5)
+	diff.SetMods(difficulty.Lazer)
+
+	player := &difficultyPlayer{diff: diff}
+	ruleset := &OsuRuleSet{}
+
+	tests := []struct {
+		delta float64
+		want  HitResult
+	}{
+		{19, Hit300},
+		{20, Hit100},
+		{59, Hit100},
+		{60, Hit50},
+		{99, Hit50},
+		{100, Miss},
+	}
+
+	for _, test := range tests {
+		if got := ruleset.GetResultForDelta(player, test.delta); got != test.want {
+			t.Errorf("delta %.0fms: got %v, want %v", test.delta, got, test.want)
+		}
+	}
+}
+
+func TestAccuracyDisplayMatchesOsuScorePage(t *testing.T) {
+	score := &Score{Accuracy: 0.9928526757795051}
+	if got := score.AccuracyDisplay(); got != 99.28 {
+		t.Fatalf("got %.2f, want 99.28", got)
+	}
+}

--- a/app/rulesets/osu/performance/api/score.go
+++ b/app/rulesets/osu/performance/api/score.go
@@ -1,13 +1,14 @@
 package api
 
 type PerfScore struct {
-	Score        int
-	Accuracy     float64
-	MaxCombo     int
-	CountGreat   int
-	CountOk      int
-	CountMeh     int
-	CountMiss    int
-	SliderBreaks int
-	SliderEnd    int
+	Score           int
+	Accuracy        float64
+	MaxCombo        int
+	CountGreat      int
+	CountOk         int
+	CountMeh        int
+	CountMiss       int
+	SliderBreaks    int
+	SliderTickTotal int
+	SliderEnd       int
 }

--- a/app/rulesets/osu/performance/performance.go
+++ b/app/rulesets/osu/performance/performance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp241007"
 	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp250306"
 	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp251020"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp260727"
 	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp26xxxx"
 	"github.com/wieku/danser-go/app/settings"
 )
@@ -32,12 +33,15 @@ func initConstructors() {
 	case "250306":
 		diffCalcInit = pp250306.NewDifficultyCalculator
 		ppCalcInit = pp250306.NewPPCalculator
+	case "251020":
+		diffCalcInit = pp251020.NewDifficultyCalculator
+		ppCalcInit = pp251020.NewPPCalculator
 	case "26xxxx":
 		diffCalcInit = pp26xxxx.NewDifficultyCalculator
 		ppCalcInit = pp26xxxx.NewPPCalculator
 	default:
-		diffCalcInit = pp251020.NewDifficultyCalculator
-		ppCalcInit = pp251020.NewPPCalculator
+		diffCalcInit = pp260727.NewDifficultyCalculator
+		ppCalcInit = pp260727.NewPPCalculator
 	}
 }
 

--- a/app/rulesets/osu/performance/pp260727/difficulty.go
+++ b/app/rulesets/osu/performance/pp260727/difficulty.go
@@ -1,0 +1,72 @@
+package pp260727
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/wieku/danser-go/app/beatmap"
+	"github.com/wieku/danser-go/app/beatmap/difficulty"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/api"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp26xxxx"
+	"github.com/wieku/danser-go/app/settings"
+)
+
+const CurrentVersion = 20260729
+
+type DifficultyCalculator struct {
+	fallback api.IDifficultyCalculator
+}
+
+func NewDifficultyCalculator() api.IDifficultyCalculator {
+	return &DifficultyCalculator{fallback: pp26xxxx.NewDifficultyCalculator()}
+}
+
+func (calculator *DifficultyCalculator) CalculateSingle(bMap *beatmap.BeatMap, diff *difficulty.Difficulty) api.Attributes {
+	variant, err := currentEngine.ensureVariantForPath(calculator.beatmapPath(bMap), diff)
+	if err != nil || len(variant.attributes) == 0 {
+		if err != nil {
+			log.Printf("Current difficulty calculator unavailable, falling back to the March 2026 preview: %v", err)
+		}
+		return calculator.fallback.CalculateSingle(bMap, diff)
+	}
+
+	return variant.attributes[len(variant.attributes)-1]
+}
+
+func (calculator *DifficultyCalculator) CalculateStep(bMap *beatmap.BeatMap, diff *difficulty.Difficulty) []api.Attributes {
+	variant, err := currentEngine.ensureVariantForPath(calculator.beatmapPath(bMap), diff)
+	if err != nil || len(variant.attributes) != len(bMap.HitObjects) {
+		if err != nil {
+			log.Printf("Current difficulty calculator unavailable, falling back to the March 2026 preview: %v", err)
+		} else {
+			log.Printf("Current difficulty calculator returned %d objects, expected %d; falling back to the March 2026 preview", len(variant.attributes), len(bMap.HitObjects))
+		}
+		return calculator.fallback.CalculateStep(bMap, diff)
+	}
+
+	attributes := make([]api.Attributes, len(variant.attributes))
+	copy(attributes, variant.attributes)
+	return attributes
+}
+
+func (calculator *DifficultyCalculator) CalculateStrainPeaks(bMap *beatmap.BeatMap, diff *difficulty.Difficulty) api.StrainPeaks {
+	variant, err := currentEngine.ensureVariantForPath(calculator.beatmapPath(bMap), diff)
+	if err != nil {
+		log.Printf("Current strain calculator unavailable, falling back to the March 2026 preview: %v", err)
+		return calculator.fallback.CalculateStrainPeaks(bMap, diff)
+	}
+
+	return variant.strains
+}
+
+func (calculator *DifficultyCalculator) beatmapPath(bMap *beatmap.BeatMap) string {
+	return filepath.Join(settings.General.GetSongsDir(), bMap.Dir, bMap.File)
+}
+
+func (calculator *DifficultyCalculator) GetVersion() int {
+	return CurrentVersion
+}
+
+func (calculator *DifficultyCalculator) GetVersionMessage() string {
+	return "2026-07-29: osu! 2026 Q2 SR & PP (reading/harmonic speed)"
+}

--- a/app/rulesets/osu/performance/pp260727/engine.go
+++ b/app/rulesets/osu/performance/pp260727/engine.go
@@ -1,0 +1,348 @@
+package pp260727
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/wieku/danser-go/app/beatmap/difficulty"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/api"
+)
+
+type calculatorEngine struct {
+	mu sync.Mutex
+
+	beatmapPath string
+	process     *exec.Cmd
+	input       io.WriteCloser
+	output      *bufio.Reader
+
+	variants map[string]*loadedVariant
+}
+
+type loadedVariant struct {
+	id         int
+	attributes []api.Attributes
+	strains    api.StrainPeaks
+}
+
+type engineResponse struct {
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result"`
+	Error  string          `json:"error"`
+}
+
+type externalAttributes struct {
+	Stars                      float64 `json:"stars"`
+	MaxCombo                   int     `json:"maxCombo"`
+	Aim                        float64 `json:"aim"`
+	Speed                      float64 `json:"speed"`
+	Flashlight                 float64 `json:"flashlight"`
+	SliderFactor               float64 `json:"sliderFactor"`
+	SpeedNoteCount             float64 `json:"speedNoteCount"`
+	AimDifficultSliderCount    float64 `json:"aimDifficultSliderCount"`
+	AimTopWeightedSliderFactor float64 `json:"aimTopWeightedSliderFactor"`
+	AimDifficultStrainCount    float64 `json:"aimDifficultStrainCount"`
+	SpeedDifficultStrainCount  float64 `json:"speedDifficultStrainCount"`
+	Reading                    float64 `json:"reading"`
+	NCircles                   int     `json:"nCircles"`
+	NSliders                   int     `json:"nSliders"`
+	NSpinners                  int     `json:"nSpinners"`
+	MaximumLegacyComboScore    int64   `json:"maximumLegacyComboScore"`
+	NestedScorePerObject       float64 `json:"nestedScorePerObject"`
+}
+
+type externalStrains struct {
+	Aim        []float64 `json:"aim"`
+	Speed      []float64 `json:"speed"`
+	Flashlight []float64 `json:"flashlight"`
+	Total      []float64 `json:"total"`
+}
+
+type loadResult struct {
+	ID         int                  `json:"id"`
+	Attributes []externalAttributes `json:"attributes"`
+	Strains    externalStrains      `json:"strains"`
+}
+
+type externalPerformance struct {
+	PP         float64 `json:"pp"`
+	Aim        float64 `json:"aim"`
+	Speed      float64 `json:"speed"`
+	Accuracy   float64 `json:"accuracy"`
+	Flashlight float64 `json:"flashlight"`
+	Reading    float64 `json:"reading"`
+}
+
+type performanceResult struct {
+	Accuracy    float64             `json:"accuracy"`
+	Performance externalPerformance `json:"performance"`
+}
+
+var currentEngine = &calculatorEngine{variants: make(map[string]*loadedVariant)}
+
+func (engine *calculatorEngine) ensureVariantForPath(path string, diff *difficulty.Difficulty) (*loadedVariant, error) {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+
+	engine.setBeatmapPathLocked(absolutePath)
+	return engine.ensureVariantLocked(diff)
+}
+
+func (engine *calculatorEngine) setBeatmapPathLocked(path string) {
+	path = filepath.Clean(path)
+	if engine.beatmapPath != path {
+		if engine.process != nil {
+			var result map[string]any
+			if err := engine.call(map[string]any{"command": "clear"}, &result); err != nil {
+				log.Printf("Failed to clear current PP runtime cache: %v", err)
+			}
+		}
+		engine.beatmapPath = path
+		clear(engine.variants)
+	}
+}
+
+func (engine *calculatorEngine) variantKey(diff *difficulty.Difficulty) (string, error) {
+	mods, err := json.Marshal(diff.ExportMods2())
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s\x00%t\x00%s", engine.beatmapPath, diff.CheckModActive(difficulty.Lazer), mods), nil
+}
+
+func (engine *calculatorEngine) ensureVariant(diff *difficulty.Difficulty) (*loadedVariant, error) {
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+
+	return engine.ensureVariantLocked(diff)
+}
+
+func (engine *calculatorEngine) ensureVariantLocked(diff *difficulty.Difficulty) (*loadedVariant, error) {
+	if engine.beatmapPath == "" {
+		return nil, errors.New("current PP calculator has no beatmap path")
+	}
+
+	key, err := engine.variantKey(diff)
+	if err != nil {
+		return nil, err
+	}
+
+	if variant := engine.variants[key]; variant != nil {
+		return variant, nil
+	}
+
+	var result loadResult
+	err = engine.call(map[string]any{
+		"command": "load",
+		"path":    engine.beatmapPath,
+		"mods":    diff.ExportMods2(),
+		"isLazer": diff.CheckModActive(difficulty.Lazer),
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	attributes := make([]api.Attributes, len(result.Attributes))
+	for i, attr := range result.Attributes {
+		attributes[i] = api.Attributes{
+			Total:                      attr.Stars,
+			Aim:                        attr.Aim,
+			AimNoSliders:               attr.Aim * attr.SliderFactor,
+			Speed:                      attr.Speed,
+			Reading:                    attr.Reading,
+			SpeedNoteCount:             attr.SpeedNoteCount,
+			AimDifficultStrainCount:    attr.AimDifficultStrainCount,
+			AimDifficultSliderCount:    attr.AimDifficultSliderCount,
+			AimTopWeightedSliderFactor: attr.AimTopWeightedSliderFactor,
+			SpeedDifficultStrainCount:  attr.SpeedDifficultStrainCount,
+			Flashlight:                 attr.Flashlight,
+			SliderFactor:               attr.SliderFactor,
+			ObjectCount:                attr.NCircles + attr.NSliders + attr.NSpinners,
+			Circles:                    attr.NCircles,
+			Sliders:                    attr.NSliders,
+			Spinners:                   attr.NSpinners,
+			MaxCombo:                   attr.MaxCombo,
+			MaximumLegacyComboScore:    attr.MaximumLegacyComboScore,
+			NestedScorePerObject:       attr.NestedScorePerObject,
+		}
+	}
+
+	variant := &loadedVariant{
+		id:         result.ID,
+		attributes: attributes,
+		strains: api.StrainPeaks{
+			Aim:        result.Strains.Aim,
+			Speed:      result.Strains.Speed,
+			Flashlight: result.Strains.Flashlight,
+			Total:      result.Strains.Total,
+		},
+	}
+	engine.variants[key] = variant
+
+	return variant, nil
+}
+
+func (engine *calculatorEngine) calculate(diff *difficulty.Difficulty, index int, score map[string]any) (performanceResult, error) {
+	variant, err := engine.ensureVariant(diff)
+	if err != nil {
+		return performanceResult{}, err
+	}
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+
+	var result performanceResult
+	err = engine.call(map[string]any{
+		"command": "performance",
+		"id":      variant.id,
+		"index":   index,
+		"score":   score,
+	}, &result)
+
+	return result, err
+}
+
+func (engine *calculatorEngine) call(request any, result any) error {
+	if engine.process == nil {
+		if err := engine.start(); err != nil {
+			return err
+		}
+	}
+
+	data, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	data = append(data, '\n')
+	if _, err = engine.input.Write(data); err != nil {
+		engine.stop()
+		return err
+	}
+
+	line, err := engine.output.ReadBytes('\n')
+	if err != nil {
+		engine.stop()
+		return err
+	}
+
+	var response engineResponse
+	if err = json.Unmarshal(line, &response); err != nil {
+		return err
+	}
+
+	if !response.OK {
+		return errors.New(response.Error)
+	}
+
+	return json.Unmarshal(response.Result, result)
+}
+
+func (engine *calculatorEngine) start() error {
+	runtimeDir, nodePath, serverPath, err := findRuntime()
+	if err != nil {
+		return err
+	}
+
+	command := exec.Command(nodePath, serverPath)
+	command.Dir = runtimeDir
+	command.Stderr = os.Stderr
+
+	input, err := command.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	output, err := command.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err = command.Start(); err != nil {
+		return err
+	}
+
+	engine.process = command
+	engine.input = input
+	engine.output = bufio.NewReader(output)
+	log.Printf("Started osu! difficulty/PP runtime from %s", runtimeDir)
+
+	return nil
+}
+
+func (engine *calculatorEngine) stop() {
+	if engine.input != nil {
+		_ = engine.input.Close()
+	}
+	if engine.process != nil && engine.process.Process != nil {
+		_ = engine.process.Process.Kill()
+		_, _ = engine.process.Process.Wait()
+	}
+
+	engine.process = nil
+	engine.input = nil
+	engine.output = nil
+}
+
+func findRuntime() (runtimeDir, nodePath, serverPath string, err error) {
+	serverName := "pp-server.cjs"
+	nodeName := "node"
+	if runtime.GOOS == "windows" {
+		nodeName = "node.exe"
+	}
+
+	candidates := make([]string, 0, 4)
+	if configured := os.Getenv("DANSER_PP_RUNTIME"); configured != "" {
+		candidates = append(candidates, configured)
+	}
+	if executable, executableErr := os.Executable(); executableErr == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(executable), "pp-runtime"))
+	}
+	if workingDirectory, workingErr := os.Getwd(); workingErr == nil {
+		candidates = append(candidates,
+			filepath.Join(workingDirectory, "pp-runtime"),
+			filepath.Join(workingDirectory, "..", "pp-runtime"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		candidate, _ = filepath.Abs(candidate)
+		server := filepath.Join(candidate, serverName)
+		node := filepath.Join(candidate, nodeName)
+		if fileExists(server) && fileExists(node) {
+			return candidate, node, server, nil
+		}
+	}
+
+	if node, lookupErr := exec.LookPath("node"); lookupErr == nil {
+		for _, candidate := range candidates {
+			candidate, _ = filepath.Abs(candidate)
+			server := filepath.Join(candidate, serverName)
+			if fileExists(server) {
+				return candidate, node, server, nil
+			}
+		}
+	}
+
+	return "", "", "", errors.New("current PP runtime not found; expected pp-runtime/node and pp-runtime/pp-server.cjs")
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/app/rulesets/osu/performance/pp260727/pp.go
+++ b/app/rulesets/osu/performance/pp260727/pp.go
@@ -1,0 +1,76 @@
+package pp260727
+
+import (
+	"log"
+
+	"github.com/wieku/danser-go/app/beatmap/difficulty"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/api"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/pp26xxxx"
+	"github.com/wieku/danser-go/app/rulesets/osu/performance/putils"
+	"github.com/wieku/danser-go/framework/math/mutils"
+)
+
+type PPv2 struct {
+	fallback api.IPerformanceCalculator
+}
+
+func NewPPCalculator() api.IPerformanceCalculator {
+	return &PPv2{fallback: pp26xxxx.NewPPCalculator()}
+}
+
+func (calculator *PPv2) Calculate(attributes api.Attributes, score api.PerfScore, diff *difficulty.Difficulty) api.PPv2Results {
+	attributes.MaxCombo = max(1, attributes.MaxCombo)
+
+	if score.MaxCombo < 0 {
+		score.MaxCombo = attributes.MaxCombo
+	}
+	if score.CountGreat < 0 {
+		score.CountGreat = attributes.ObjectCount - score.CountOk - score.CountMeh - score.CountMiss
+	}
+	if score.SliderEnd < 0 {
+		score.SliderEnd = attributes.Sliders
+	}
+
+	index := max(0, attributes.ObjectCount-1)
+	largeTickMisses := max(0, score.SliderBreaks)
+	largeTickHits := max(0, score.SliderTickTotal-largeTickMisses)
+
+	result, err := currentEngine.calculate(diff, index, map[string]any{
+		"totalScore":      score.Score,
+		"isLegacyScore":   !diff.CheckModActive(difficulty.Lazer),
+		"accuracy":        score.Accuracy,
+		"maxCombo":        score.MaxCombo,
+		"sliderEndHits":   score.SliderEnd,
+		"comboBreaks":     score.SliderBreaks,
+		"largeTickHits":   largeTickHits,
+		"largeTickMisses": largeTickMisses,
+		"greats":          score.CountGreat,
+		"oks":             score.CountOk,
+		"mehs":            score.CountMeh,
+		"misses":          score.CountMiss,
+	})
+	if err != nil {
+		log.Printf("Current performance calculator unavailable, falling back to the March 2026 preview: %v", err)
+		return calculator.fallback.Calculate(attributes, score, diff)
+	}
+
+	return api.PPv2Results{
+		Aim:        result.Performance.Aim,
+		Speed:      result.Performance.Speed,
+		Acc:        result.Performance.Accuracy,
+		Flashlight: result.Performance.Flashlight,
+		Cognition:  combineCognition(result.Performance.Reading, result.Performance.Flashlight),
+		Total:      result.Performance.PP,
+	}
+}
+
+func combineCognition(reading, flashlight float64) float64 {
+	if reading <= 0 {
+		return flashlight
+	}
+	if flashlight <= 0 {
+		return reading
+	}
+
+	return putils.Norm(1.1, reading, flashlight*mutils.Clamp(flashlight/reading, 0.25, 1))
+}

--- a/app/rulesets/osu/ruleset.go
+++ b/app/rulesets/osu/ruleset.go
@@ -359,7 +359,7 @@ func (set *OsuRuleSet) printEndTable() {
 		data = append(data, fmt.Sprintf("%d", i+1))
 		data = append(data, c.Name)
 		data = append(data, utils.Humanize(set.cursors[c].scoreProcessor.GetScore()))
-		data = append(data, fmt.Sprintf("%.2f", set.cursors[c].score.Accuracy*100))
+		data = append(data, fmt.Sprintf("%.2f", set.cursors[c].score.AccuracyDisplay()))
 		data = append(data, set.cursors[c].score.Grade.String())
 		data = append(data, utils.Humanize(set.cursors[c].score.Count300))
 		data = append(data, utils.Humanize(set.cursors[c].score.Count100))
@@ -558,7 +558,7 @@ func (set *OsuRuleSet) SendResult(cursor *graphics.Cursor, judgementResult Judge
 			subSet.scoreProcessor.GetCombo(),
 			subSet.score.Combo,
 			subSet.scoreProcessor.GetScore(),
-			subSet.score.Accuracy*100,
+			subSet.score.AccuracyDisplay(),
 			subSet.score.Count300,
 			subSet.score.Count100,
 			subSet.score.Count50,

--- a/app/rulesets/osu/score.go
+++ b/app/rulesets/osu/score.go
@@ -1,6 +1,8 @@
 package osu
 
 import (
+	"math"
+
 	"github.com/wieku/danser-go/app/beatmap"
 	"github.com/wieku/danser-go/app/beatmap/difficulty"
 	"github.com/wieku/danser-go/app/rulesets/osu/performance/api"
@@ -13,6 +15,12 @@ type scoreProcessor interface {
 	GetScore() int64
 	GetCombo() int64
 	GetAccuracy() float64
+}
+
+// AccuracyDisplay returns the two-decimal percentage shown by osu!'s score
+// pages. osu! truncates this value rather than rounding it.
+func (s *Score) AccuracyDisplay() float64 {
+	return math.Floor(s.Accuracy*10000) / 100
 }
 
 type Score struct {
@@ -39,15 +47,16 @@ type Score struct {
 
 func (s *Score) ToPerfScore() api.PerfScore {
 	return api.PerfScore{
-		Score:        int(s.Score),
-		MaxCombo:     int(s.Combo),
-		CountGreat:   int(s.Count300),
-		CountOk:      int(s.Count100),
-		CountMeh:     int(s.Count50),
-		CountMiss:    int(s.CountMiss),
-		SliderBreaks: int(s.CountSB),
-		SliderEnd:    int(s.SliderEnd),
-		Accuracy:     s.Accuracy,
+		Score:           int(s.Score),
+		MaxCombo:        int(s.Combo),
+		CountGreat:      int(s.Count300),
+		CountOk:         int(s.Count100),
+		CountMeh:        int(s.Count50),
+		CountMiss:       int(s.CountMiss),
+		SliderBreaks:    int(s.CountSB),
+		SliderTickTotal: int(s.MaxTicks),
+		SliderEnd:       int(s.SliderEnd),
+		Accuracy:        s.Accuracy,
 	}
 }
 

--- a/app/settings/gameplay.go
+++ b/app/settings/gameplay.go
@@ -273,7 +273,7 @@ type gameplay struct {
 	FlashlightDim           float64
 	PlayUsername            string `liveedit:"false"`
 	IgnoreFailsInReplays    bool
-	PPVersion               string `liveedit:"false" label:"PP counter version" combo:"211112|2021 pp rework (First Xexxar),220930|2022 pp rework,241007|2024 pp rework,250306|2025 Q1 update,26xxxx|Upcoming,latest|2025 Q4 update (latest)"`
+	PPVersion               string `liveedit:"false" label:"PP counter version" combo:"211112|2021 pp rework (First Xexxar),220930|2022 pp rework,241007|2024 pp rework,250306|2025 Q1 update,251020|2025 Q4 update,26xxxx|March 2026 preview,latest|2026 Q2 SR & PP (latest)"`
 	LazerClassicScore       bool   `label:"Use \"Classic\" score for osu!lazer plays"`
 	AlwaysSkipIntro         bool   `liveedit:"false"`
 }

--- a/app/states/components/overlays/play/ranking.go
+++ b/app/states/components/overlays/play/ranking.go
@@ -184,7 +184,7 @@ func NewRankingPanel(cursor *graphics.Cursor, ruleset *osu.OsuRuleSet, hitError 
 
 	panel.score = fmt.Sprintf("%08d", score.Score)
 	panel.maxCombo = fmt.Sprintf("%dx", score.Combo)
-	panel.accuracy = fmt.Sprintf("%.2f%%", score.Accuracy*100)
+	panel.accuracy = fmt.Sprintf("%.2f%%", score.AccuracyDisplay())
 
 	panel.hpGraph = make([]vector.Vector2d, len(hpGraph))
 	copy(panel.hpGraph, hpGraph)

--- a/dist-linux.sh
+++ b/dist-linux.sh
@@ -24,6 +24,12 @@ go build -trimpath -ldflags "-s -w -X 'github.com/wieku/danser-go/build.VERSION=
 mv $BUILD_DIR/danser-core.so $BUILD_DIR/libdanser-core.so
 cp {libbass.so,libbass_fx.so,libbassmix.so,libyuv.so,libSDL3.so} $BUILD_DIR/
 
+pnpm --dir pp-runtime install --prod --frozen-lockfile
+mkdir -p $BUILD_DIR/pp-runtime
+cp pp-runtime/{pp-server.cjs,package.json,pnpm-lock.yaml,README.md} $BUILD_DIR/pp-runtime/
+cp -r pp-runtime/node_modules $BUILD_DIR/pp-runtime/
+cp "$(command -v node)" $BUILD_DIR/pp-runtime/node
+
 gcc -no-pie --verbose -O3 -o $BUILD_DIR/danser-cli -I. cmain/main_danser.c -I$BUILD_DIR/ -Wl,-rpath,'$ORIGIN' -L$BUILD_DIR/ -ldanser-core
 
 gcc -no-pie --verbose -O3 -D LAUNCHER -o $BUILD_DIR/danser -I. cmain/main_danser.c -I$BUILD_DIR/ -Wl,-rpath,'$ORIGIN' -L$BUILD_DIR/ -ldanser-core

--- a/dist-win.sh
+++ b/dist-win.sh
@@ -78,6 +78,12 @@ $resgen <<< $resDanser
 
 cp {bass.dll,bass_fx.dll,bassmix.dll,libyuv.dll,SDL3.dll} $BUILD_DIR/
 
+pnpm --dir pp-runtime install --prod --frozen-lockfile
+mkdir -p $BUILD_DIR/pp-runtime
+cp pp-runtime/{pp-server.cjs,package.json,pnpm-lock.yaml,README.md} $BUILD_DIR/pp-runtime/
+cp -r pp-runtime/node_modules $BUILD_DIR/pp-runtime/
+cp "$(command -v node)" $BUILD_DIR/pp-runtime/node.exe
+
 $CC <<< --verbose -O3 -o $BUILD_DIR/danser-cli.exe -I. cmain/main_danser.c -I$BUILD_DIR/ -L$BUILD_DIR/ -ldanser-core $BUILD_DIR/danser.syso -municode
 
 $resgen <<< $resLauncher

--- a/pp-runtime/.gitignore
+++ b/pp-runtime/.gitignore
@@ -1,0 +1,3 @@
+node
+node.exe
+node_modules/

--- a/pp-runtime/README.md
+++ b/pp-runtime/README.md
@@ -1,0 +1,16 @@
+# danser current osu! difficulty/PP runtime
+
+This helper exposes the current osu!lazer difficulty and performance calculator
+to danser over a local JSON-lines pipe. It is intentionally kept out of the
+render loop: beatmap difficulty attributes are calculated once, while live PP
+is updated from danser's simulated hit results.
+
+Install production dependencies with Node.js 24 and pnpm:
+
+```text
+pnpm install --prod --frozen-lockfile
+```
+
+The runtime uses `@tosuapp/lazer-calculator-prebuilt`, an LGPL-3.0 binding of
+osu!lazer's calculator. Its license is installed with the package under
+`node_modules`.

--- a/pp-runtime/package.json
+++ b/pp-runtime/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "danser-pp-runtime",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@tosuapp/lazer-calculator-prebuilt": "0.6.1-20260729-main.0"
+  }
+}

--- a/pp-runtime/pnpm-lock.yaml
+++ b/pp-runtime/pnpm-lock.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tosuapp/lazer-calculator-prebuilt':
+        specifier: 0.6.1-20260729-main.0
+        version: 0.6.1-20260729-main.0
+
+packages:
+
+  '@tosuapp/lazer-calculator-linux-x64@0.6.1-20260729-main.0':
+    resolution: {integrity: sha512-z6JQt9Y2Gp3DqA2UWjOhaiZQVWQ1kDPJx10e3n6+NcUKgw8YwsKrTWFfgs7lmiVDiE0YBxtxfWRxZpyRpnofcQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@tosuapp/lazer-calculator-prebuilt@0.6.1-20260729-main.0':
+    resolution: {integrity: sha512-ymhZSBU/SZuMGD+4j35AcngBhFhjJWvokhfTWbFTYE8hAX2xVGFIsh1rhBoZvqY95yTdnVjFay/qMMsjZLVZng==}
+    cpu: [x64]
+    os: [win32, linux]
+
+  '@tosuapp/lazer-calculator-win32-x64@0.6.1-20260729-main.0':
+    resolution: {integrity: sha512-HhWNJuhFEDk5InEZLD63hQIMfP5qnBGF4V2pPiL/FsAxcNLgY8PjsqxrwhOGy9c8secwLqI+F/OxLYCoBPmXVA==}
+    cpu: [x64]
+    os: [win32]
+
+snapshots:
+
+  '@tosuapp/lazer-calculator-linux-x64@0.6.1-20260729-main.0':
+    optional: true
+
+  '@tosuapp/lazer-calculator-prebuilt@0.6.1-20260729-main.0':
+    optionalDependencies:
+      '@tosuapp/lazer-calculator-linux-x64': 0.6.1-20260729-main.0
+      '@tosuapp/lazer-calculator-win32-x64': 0.6.1-20260729-main.0
+
+  '@tosuapp/lazer-calculator-win32-x64@0.6.1-20260729-main.0':
+    optional: true

--- a/pp-runtime/pp-server.cjs
+++ b/pp-runtime/pp-server.cjs
@@ -1,0 +1,142 @@
+const fs = require("node:fs");
+const readline = require("node:readline");
+const { PlayBeatmap } = require("@tosuapp/lazer-calculator-prebuilt");
+
+const variants = new Map();
+const cache = new Map();
+let nextId = 1;
+
+function normaliseMods(mods, isLazer) {
+  const result = (mods ?? [])
+    .filter((mod) => mod.acronym !== "LZ")
+    .map((mod) => ({
+      acronym: mod.acronym,
+      settings: new Map(Object.entries(mod.settings ?? {})),
+    }));
+
+  if (!isLazer && !result.some((mod) => mod.acronym === "CL")) {
+    result.push({ acronym: "CL", settings: new Map() });
+  }
+
+  return result;
+}
+
+function loadBeatmap(request) {
+  const cacheKey = JSON.stringify([
+    request.path,
+    request.mods ?? [],
+    request.isLazer,
+  ]);
+  const cachedId = cache.get(cacheKey);
+
+  if (cachedId !== undefined) {
+    const cached = variants.get(cachedId);
+    return {
+      id: cachedId,
+      attributes: cached.attributeData,
+      strains: cached.strains,
+    };
+  }
+
+  const beatmap = PlayBeatmap.parse(fs.readFileSync(request.path, "utf8"));
+  beatmap.applyMods(normaliseMods(request.mods, request.isLazer));
+
+  const gradual = beatmap.createGradualDifficulty();
+  const attributes = [];
+  const attributeData = [];
+
+  while (gradual.advance()) {
+    const current = gradual.createDifficultyAttrs();
+    attributes.push(current);
+    attributeData.push(current.getData());
+  }
+
+  const currentStrains = gradual.getCurrentStrains();
+  const strains = {
+    aim: Array.from(currentStrains.aim.value),
+    speed: Array.from(currentStrains.speed.value),
+    flashlight: Array.from(currentStrains.flashlight.value),
+    reading: Array.from(currentStrains.reading.value),
+    total: Array.from(currentStrains.strains.value),
+  };
+
+  const id = nextId++;
+  variants.set(id, { beatmap, attributes, attributeData, strains });
+  cache.set(cacheKey, id);
+
+  return { id, attributes: attributeData, strains };
+}
+
+function calculatePerformance(request) {
+  const variant = variants.get(request.id);
+
+  if (!variant) throw new Error(`Unknown beatmap variant ${request.id}`);
+
+  const index = Math.max(
+    0,
+    Math.min(request.index, variant.attributes.length - 1),
+  );
+  const score = {
+    totalScore: 0,
+    isLegacyScore: false,
+    accuracy: 0,
+    maxCombo: 0,
+    sliderEndHits: 0,
+    comboBreaks: 0,
+    ignoreHits: 0,
+    ignoreMisses: 0,
+    largeBonuses: 0,
+    smallBonuses: 0,
+    largeTickHits: 0,
+    largeTickMisses: 0,
+    smallTickHits: 0,
+    smallTickMisses: 0,
+    perfects: 0,
+    greats: 0,
+    goods: 0,
+    oks: 0,
+    mehs: 0,
+    misses: 0,
+    ...request.score,
+  };
+
+  score.accuracy = variant.beatmap.calculateAccuracy(score);
+
+  return {
+    accuracy: score.accuracy,
+    performance: variant.beatmap.calculatePerformance(
+      variant.attributes[index],
+      score,
+    ),
+  };
+}
+
+function handle(request) {
+  switch (request.command) {
+    case "load":
+      return loadBeatmap(request);
+    case "performance":
+      return calculatePerformance(request);
+    case "ping":
+      return { version: "20260729" };
+    case "clear":
+      variants.clear();
+      cache.clear();
+      return {};
+    default:
+      throw new Error(`Unknown command ${request.command}`);
+  }
+}
+
+const input = readline.createInterface({ input: process.stdin });
+
+input.on("line", (line) => {
+  try {
+    const request = JSON.parse(line);
+    process.stdout.write(`${JSON.stringify({ ok: true, result: handle(request) })}\n`);
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify({ ok: false, error: error?.stack ?? String(error) })}\n`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- update osu!lazer score V2 multipliers, including the current 1.09× Hard Rock multiplier and configurable mod multipliers
- use the 2026-07-29 osu! difficulty/performance calculator for live PP while retaining the older selectable calculators
- match osu!'s two-decimal accuracy presentation and pass complete lazer slider-tick results into PP calculation
- package the local calculator runtime in Windows and Linux release builds

## Replay verification

Validated end to end with [score 7245425354](https://osu.ppy.sh/scores/7245425354). Danser simulates the replay's cursor/key input and now produces the same result as osu!:

- 946×300 / 12×100 / 0×50 / 0 misses
- 1,299× combo
- 99.28% accuracy
- 1,068,050 score
- 501.82pp (displayed as 502pp by osu!)

The judgement difference was an OD10 boundary hit: the replay has a +20 ms hit, outside lazer's 19.5 ms GREAT window. This is correctly judged as OK on the current dev branch.

## Verification

- `go test -tags "gl21,glfw" ./app/beatmap/difficulty ./app/rulesets/osu ./app/rulesets/osu/performance/pp260727 ./app/database`
- `go vet -tags "gl21,glfw" ./app/beatmap/difficulty ./app/rulesets/osu ./app/rulesets/osu/performance/pp260727 ./app/database`
- full replay simulation through the Windows release build

The current calculator runs locally over a JSON-lines pipe using `@tosuapp/lazer-calculator-prebuilt`; its LGPL-3.0 license is included with the packaged dependency.